### PR TITLE
Fixed 2880 byte padding issue

### DIFF
--- a/src/extractor.cpp
+++ b/src/extractor.cpp
@@ -932,7 +932,7 @@ void combineFITS( const QStringList & inputFilenames, const QString & outputFile
     }
 
     int pad = 2880 - ofp.pos() % 2880;
-    if( pad > 0) {
+    if(0 < pad && pad < 2880) {
         cerr << "Padding with " << pad << " bytes.\n";
         std::vector<char> buff(pad,0);
         if( ! blockWrite( ofp, buff.data(), pad)) {


### PR DESCRIPTION
Should no longer pad by exactly 2880 bytes when file size is already multiple of 2880. Should now allow opening via Astropy, and kvis shouldn't complain about invalid headers anymore.
